### PR TITLE
convert docx into pdf and store converted pdf in subfolder, corresponding adjustment in UI

### DIFF
--- a/appl-docchat.yml
+++ b/appl-docchat.yml
@@ -43,9 +43,9 @@ dependencies:
     - deepdiff==7.0.1
     - deprecated==1.2.14
     - dill==0.3.8
-    - diskcache==5.6.3
     - distro==1.9.0
     - dnspython==2.6.1
+    - docx2pdf==0.1.8
     - email-validator==2.1.1
     - emoji==2.12.1
     - fastapi==0.111.0
@@ -87,7 +87,6 @@ dependencies:
     - langchain-text-splitters==0.2.1
     - langdetect==1.0.9
     - langsmith==0.1.77
-    - llama-cpp-python==0.2.76
     - loguru==0.7.2
     - lxml==5.2.2
     - markdown-it-py==3.0.0
@@ -148,6 +147,7 @@ dependencies:
     - python-magic==0.4.27
     - python-multipart==0.0.9
     - pytz==2024.1
+    - pywin32==308
     - pyyaml==6.0.1
     - ragas==0.1.9
     - rank-bm25==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,9 +26,9 @@ deepdiff==7.0.1
 defusedxml==0.7.1
 Deprecated==1.2.14
 dill==0.3.8
-diskcache==5.6.3
 distro==1.9.0
 dnspython==2.6.1
+docx2pdf==0.1.8
 email_validator==2.1.1
 emoji==2.12.1
 fastapi==0.111.0
@@ -70,7 +70,6 @@ langchain-openai==0.1.8
 langchain-text-splitters==0.2.1
 langdetect==1.0.9
 langsmith==0.1.77
-llama_cpp_python==0.2.76
 loguru==0.7.2
 lxml==5.2.2
 markdown-it-py==3.0.0
@@ -132,6 +131,7 @@ python-iso639==2024.4.27
 python-magic==0.4.27
 python-multipart==0.0.9
 pytz==2024.1
+pywin32==308
 PyYAML==6.0.1
 ragas==0.1.9
 rank-bm25==0.2.2
@@ -163,7 +163,6 @@ tbb==2021.12.0
 tenacity==8.3.0
 threadpoolctl==3.5.0
 tiktoken==0.7.0
-tinycss2==1.2.1
 tokenizers==0.19.1
 toml==0.10.2
 toolz==0.12.1

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -294,10 +294,13 @@ def handle_query(my_folder_path_selected: str,
         with st.expander("Paragraphs used for answer"):
             for i, document in enumerate(response["source_documents"]):
                 filename = document.metadata['filename']
-                docpath = os.path.join(my_folder_path_selected, filename)
+                if filename.endswith(".docx"):
+                    docpath = os.path.join(my_folder_path_selected, "conversions", filename + ".pdf")
+                else:
+                    docpath = os.path.join(my_folder_path_selected, filename)
                 pagenr = document.metadata['page_number']
                 content = document.page_content
-                if filename.endswith(".pdf"):
+                if (filename.endswith(".pdf")) or (filename.endswith(".docx")):
                     exp_textcol, _, exp_imgcol = st.columns([0.3, 0.1, 0.6])
                 else:
                     exp_textcol, _ = st.columns([0.9, 0.1])
@@ -305,7 +308,7 @@ def handle_query(my_folder_path_selected: str,
                     # add 1 to metadata page_number because that starts at 0
                     st.write(f"**file: {filename}, page {pagenr + 1}**")
                     st.write(f"{document.page_content}")
-                if filename.endswith(".pdf"):
+                if (filename.endswith(".pdf")) or (filename.endswith(".docx")):
                     with exp_imgcol:
                         doc = fitz.open(docpath)
                         page = doc.load_page(pagenr)


### PR DESCRIPTION
Hi @saidcetinkaya, I decided to go for docx conversion only.
html conversion was really bad with xhtml2pdf package and I didn't like separate install of w khtmltopdf executable (for distribution reasons)
txt conversion messed up the layout of the txt file so page numbers.

Apart from that I simplified adjustments in ingester.py by just looking in content folder for changes, not in conversion subfolder. I can do this because of small adjustment in metadata (see fileparser.py)