### PR TITLE
New tab added to change settings.

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,7 +1,7 @@
 """
 Streamlit User Interface for chatting with documents
 """
-from typing import List
+from typing import List, Dict
 import os
 import fitz
 import streamlit as st
@@ -318,6 +318,10 @@ def handle_query(my_folder_path_selected: str,
             my_querier.make_chain(my_folder_name_selected, my_vecdb_folder_path_selected, search_filter=my_filter)
         else:
             my_querier.make_chain(my_folder_name_selected, my_vecdb_folder_path_selected)
+        # reload chat history if it is cleared by a change in settings
+        if (len(st.session_state['chat_history']) > 0) and (my_querier.chat_history == []):
+            my_querier.chat_history = st.session_state['chat_history']
+            logger.info("chat history retained")
         response = my_querier.ask_question(my_prompt)
     # Display the response in chat message container
     with st.chat_message("assistant"):
@@ -336,28 +340,42 @@ def handle_query(my_folder_path_selected: str,
         logger.info("No source documents found relating to the question")
     logger.info("Executed handle_query(querier, prompt)")
 
+    # to retain chat history in case of a change in settings
+    st.session_state['chat_history'] = my_querier.chat_history.copy()
 
 @st.cache_data
 def initialize_page() -> None:
     """
     Initializes the main page with a page header and app info
     """
-    # Custom CSS to have white expander background
+
+    # Custom CSS to have white expander background and fixed chat input
     st.markdown(
         '''
         <style>
         .streamlit-expanderHeader {
             background-color: white;
-            color: black; # Expander header color
+            color: black;
         }
         .streamlit-expanderContent {
             background-color: white;
-            color: black; # Expander content color
+            color: black;
         }
+        /* Fixed chat input */
+        .st-key-chat_input {
+            position: fixed !important;
+            bottom: 0 !important;
+            background: white !important;
+            padding: 1rem 0 2rem 0 !important;
+            z-index: 999999 !important;
+            margin: 0 !important;
+        }
+        
         </style>
         ''',
         unsafe_allow_html=True
     )
+
     _, col2, _ = st.columns([0.4, 0.2, 0.4])
     with col2:
         st.header(settings.APP_HEADER)
@@ -399,6 +417,10 @@ def initialize_session_state() -> None:
         st.session_state['confidential'] = False
     if 'messages' not in st.session_state:
         st.session_state['messages'] = []
+    # chat history is stored in session state to retain it in case of a change in settings
+    if 'chat_history' not in st.session_state:
+        st.session_state['chat_history'] = []
+    initialize_settings_state()
 
 
 # @st.cache_resource
@@ -445,118 +467,322 @@ def set_page_config() -> None:
     logger.info("\nExecuted set_page_config()")
 
 
+def get_provider_models() -> Dict[str, Dict[str, List[str]]]:
+    """
+    Returns a dictionary of available models for each provider type
+    """
+    return {
+        'embeddings': {
+            'openai': [
+                "text-embedding-ada-002",
+                "text-embedding-3-small",
+                "text-embedding-3-large"
+            ],
+            'huggingface': [
+                "all-mpnet-base-v2"
+            ],
+            'ollama': [
+                "llama3",
+                "nomic-embed-text"
+            ],
+            'azureopenai': [
+                "text-embedding-ada-002",
+                "text-embedding-3-large"
+            ]
+        },
+        'llm': {
+            'openai': [
+                "gpt-3.5-turbo",
+                "gpt-3.5-turbo-16k",
+                "gpt-4",
+                "gpt-4o"
+            ],
+            'huggingface': [
+                "meta-llama/Llama-2-7b-chat-hf",
+                "google/flan-t5-base"
+            ],
+            'ollama': [
+                "llama3",
+                "orca-mini",
+                "zephyr"
+            ],
+            'azureopenai': [
+                "gpt-35-turbo",
+                "gpt-4",
+                "gpt-4o"
+            ]
+        }
+    }
+
+def initialize_settings_state():
+    """Initialize session state for settings if not already present"""
+    if 'settings' not in st.session_state:
+        st.session_state.settings = {
+            'TEXT_SPLITTER_METHOD': settings.TEXT_SPLITTER_METHOD,
+            'EMBEDDINGS_PROVIDER': settings.EMBEDDINGS_PROVIDER,
+            'EMBEDDINGS_MODEL': settings.EMBEDDINGS_MODEL,
+            'RETRIEVER_TYPE': settings.RETRIEVER_TYPE,
+            'RERANK': settings.RERANK,
+            'LLM_PROVIDER': settings.LLM_PROVIDER,
+            'LLM_MODEL': settings.LLM_MODEL
+        }
+
+def render_settings_tab():
+    """Render the settings tab content"""
+
+    st.header("RAG Settings")
+    
+    # Text Splitter Method
+    st.subheader("Text Processing")
+    text_splitter_options = ["RecursiveCharacterTextSplitter", "NLTKTextSplitter"]
+    selected_splitter = st.selectbox(
+        "Text Splitter Method",
+        options=text_splitter_options,
+        index=text_splitter_options.index(st.session_state.settings['TEXT_SPLITTER_METHOD']),
+        key='splitter'
+    )
+
+    # Embeddings Configuration
+    st.subheader("Embeddings Configuration")
+    embeddings_providers = ["openai", "huggingface", "ollama", "azureopenai"]
+    selected_embeddings_provider = st.selectbox(
+        "Embeddings Provider",
+        options=embeddings_providers,
+        index=embeddings_providers.index(st.session_state.settings['EMBEDDINGS_PROVIDER']),
+        key='emb_provider'
+    )
+
+    # Get available models for selected provider
+    provider_models = get_provider_models()
+    available_embedding_models = provider_models['embeddings'][selected_embeddings_provider]
+    
+    # Default to first available model if current isn't available for selected provider
+    current_emb_model = st.session_state.settings['EMBEDDINGS_MODEL']
+    if current_emb_model not in available_embedding_models:
+        current_emb_model = available_embedding_models[0]
+    
+    selected_embedding_model = st.selectbox(
+        "Embeddings Model",
+        options=available_embedding_models,
+        index=available_embedding_models.index(current_emb_model),
+        key='emb_model'
+    )
+
+    # Retriever Configuration
+    st.subheader("Retriever Configuration")
+    retriever_types = ["vectorstore", "hybrid", "parent"]
+    selected_retriever = st.selectbox(
+        "Retriever Type",
+        options=retriever_types,
+        index=retriever_types.index(st.session_state.settings['RETRIEVER_TYPE']),
+        key='retriever'
+    )
+
+    rerank_enabled = st.checkbox(
+        "Enable Reranking",
+        value=st.session_state.settings['RERANK'],
+        key='rerank'
+    )
+
+    # LLM Configuration
+    st.subheader("Language Model Configuration")
+    llm_providers = ["openai", "huggingface", "ollama", "azureopenai"]
+    selected_llm_provider = st.selectbox(
+        "LLM Provider",
+        options=llm_providers,
+        index=llm_providers.index(st.session_state.settings['LLM_PROVIDER']),
+        key='llm_provider'
+    )
+
+    # Get available models for selected provider
+    available_llm_models = provider_models['llm'][selected_llm_provider]
+    
+    # Default to first available model if current isn't available for selected provider
+    current_llm_model = st.session_state.settings['LLM_MODEL']
+    if current_llm_model not in available_llm_models:
+        current_llm_model = available_llm_models[0]
+    
+    selected_llm_model = st.selectbox(
+        "LLM Model",
+        options=available_llm_models,
+        index=available_llm_models.index(current_llm_model),
+        key='llm_model'
+    )
+
+    # Save Settings Button
+    if st.button("Save Settings", type="primary"): 
+        # Update settings in session state
+        if not st.session_state['confidential']:
+            st.session_state.settings.update({
+                'TEXT_SPLITTER_METHOD': selected_splitter,
+                'EMBEDDINGS_PROVIDER': selected_embeddings_provider,
+                'EMBEDDINGS_MODEL': selected_embedding_model,
+                'RETRIEVER_TYPE': selected_retriever,
+                'RERANK': rerank_enabled,
+                'LLM_PROVIDER': selected_llm_provider,
+                'LLM_MODEL': selected_llm_model
+            })
+            # Update the settings module
+            settings.TEXT_SPLITTER_METHOD = selected_splitter
+            settings.EMBEDDINGS_PROVIDER = selected_embeddings_provider
+            settings.EMBEDDINGS_MODEL = selected_embedding_model
+            settings.RETRIEVER_TYPE = selected_retriever
+            settings.RERANK = rerank_enabled
+            settings.LLM_PROVIDER = selected_llm_provider
+            settings.LLM_MODEL = selected_llm_model
+            
+            st.success("Settings saved successfully!")
+            
+            # Log current settings
+            st.write("Current Settings:")
+            st.json(st.session_state.settings)
+        else:
+            st.error("Confidential mode is enabled. Settings cannot be changed.")
+
+def render_chat_tab():
+    # initialize page, executed only once per session
+    initialize_page()
+    # Create button to exit the application. This button sets session_state['is_EXIT_clicked'] to True
+    st.sidebar.button("EXIT", type="primary", on_click=click_exit_button)
+    # initialize logo, executed only once per session
+    initialize_logo()
+    # initialize session state variables
+    initialize_session_state()
+    # allow user to set the path to the document folder
+    folder_path_selected = st.sidebar.text_input(label="***ENTER THE DOCUMENT FOLDER PATH***",
+                                                help="""Please enter the full path e.g. Y:/User/troosts/chatpbl/...""")
+    if st.session_state['is_EXIT_clicked']:
+        ut.exit_ui()
+    if folder_path_selected != "":
+        # get folder name with docs
+        folder_name_selected = os.path.basename(folder_path_selected)
+        # available and selected documents
+        document_names = documentlist_creator(folder_path_selected)
+        document_selection = document_selector(document_names)
+        # create checkbox to indicate whether chosen documents are private or not. Default is not checked
+        # confidential = st.sidebar.checkbox(label="confidential", help="check in case of private documents")
+        confidential = False
+        # get relevant models
+        if confidential:
+            llm_provider, llm_model, embeddings_provider, embeddings_model = ut.get_relevant_models(summary=False,
+                                                                                                private=confidential)
+        else:
+            llm_provider = st.session_state.settings['LLM_PROVIDER']
+            llm_model = st.session_state.settings['LLM_MODEL']
+            embeddings_provider = st.session_state.settings['EMBEDDINGS_PROVIDER']
+            embeddings_model = st.session_state.settings['EMBEDDINGS_MODEL']
+
+        # creation of Querier object, executed only once per session
+        querier = initialize_querier(my_llm_provider=llm_provider,
+                                    my_llm_model=llm_model,
+                                    my_embeddings_provider=embeddings_provider,
+                                    my_embeddings_model=embeddings_model)
+        
+        # If a different folder or (set of) document(s) is chosen,
+        # clear querier history and
+        # set the go button session state 'is_go_clicked' to False
+        if ((folder_name_selected != st.session_state['folder_selected']) or
+        (document_selection != st.session_state['documents_selected'])):
+            querier.clear_history()
+            st.session_state['chat_history'] = []
+            st.session_state['is_GO_clicked'] = False
+        st.session_state['folder_selected'] = folder_name_selected
+        st.session_state['documents_selected'] = document_selection
+
+        # clear querier history if a switch in confidentiality is made
+        if confidential != st.session_state['confidential']:
+            querier.clear_history()
+            st.session_state['chat_history'] = []
+            st.session_state['is_GO_clicked'] = False
+        st.session_state['confidential'] = confidential
+
+        # create radio button group for summarization
+        summary_type = st.sidebar.radio(
+                                        label="Start with summary?",
+                                        options=["No", "Short", "Long"],
+                                        captions=["", "Quicker and shorter", "Slower but more extensive"],
+                                        index=0
+                                    )
+        # when a different summary choice is made, set the go button session state 'is_go_clicked' to False
+        if summary_type != st.session_state['is_summary_clicked']:
+            st.session_state['is_GO_clicked'] = False
+        st.session_state['is_summary_clicked'] = summary_type
+
+        # create button to confirm folder selection. This button sets session_state['is_GO_clicked'] to True when clicked
+        st.sidebar.button(label="GO", type="primary", on_click=click_go_button,
+                        help="show the prompt bar at the bottom of the screen to take questions")
+
+        # only start a conversation when a folder is selected and selection is confirmed with "GO" button
+        if st.session_state['is_GO_clicked']:
+            logger.info("GO button is clicked")
+            if len(document_selection) > 0:
+                # get relevant models
+                _, _, embeddings_provider, embeddings_model = ut.get_relevant_models(summary=False,
+                                                                                    private=confidential)
+
+                # determine name of associated vector database
+                vecdb_folder_path = ut.create_vectordb_path(content_folder_path=folder_path_selected,
+                                                            embeddings_provider=embeddings_provider,
+                                                            embeddings_model=embeddings_model)
+                # create or update vector database if necessary
+                check_vectordb(my_querier=querier,
+                            my_folder_name_selected=folder_name_selected,
+                            my_folder_path_selected=folder_path_selected,
+                            my_documents_selected=document_selection,
+                            my_vecdb_folder_path_selected=vecdb_folder_path,
+                            my_embeddings_provider=embeddings_provider,
+                            my_embeddings_model=embeddings_model)
+                # if one of the options is chosen
+                if summary_type in ["Short", "Long"]:
+                    # show the summary at the top of the screen
+                    create_and_show_summary(my_summary_type=summary_type,
+                                            my_folder_path_selected=folder_path_selected,
+                                            my_selected_documents=document_selection)
+                # show button "Clear Conversation"
+                clear_messages_button = st.button(label="Clear Conversation", key="clear")
+                # if button "Clear Conversation" is clicked
+                if clear_messages_button:
+                    # clear all chat messages on screen and in Querier object
+                    # NB: session state of "is_GO_clicked" and "folder_selected" remain unchanged
+                    st.session_state['messages'] = []
+                    querier.clear_history()
+                    st.session_state['chat_history'] = []
+                    st.session_state['is_GO_clicked'] = False
+                    logger.info("Clear Conversation button clicked")
+                # display chat messages from history
+                # path is needed to show source documents after the assistant's response
+                display_chat_history(folder_path_selected)
+                # react to user input if a question has been asked
+                prompt = st.chat_input("Your question", key="chat_input")
+                if prompt:
+                    handle_query(my_folder_path_selected=folder_path_selected,
+                                my_querier=querier,
+                                my_prompt=prompt,
+                                my_document_selection=document_selection,
+                                my_folder_name_selected=folder_name_selected,
+                                my_vecdb_folder_path_selected=vecdb_folder_path,
+                                question_number=len(st.session_state['messages']))
+            else:
+                st.write("Please choose one or more documents")
+
+
+
+
 # ### MAIN PROGRAM ####
 # set page configuration, this is the first thing that needs to be done
 set_page_config()
-# initialize page, executed only once per session
-initialize_page()
-# Create button to exit the application. This button sets session_state['is_EXIT_clicked'] to True
-st.sidebar.button("EXIT", type="primary", on_click=click_exit_button)
-# initialize logo, executed only once per session
-initialize_logo()
-# initialize session state variables
-initialize_session_state()
-# allow user to set the path to the document folder
-folder_path_selected = st.sidebar.text_input(label="***ENTER THE DOCUMENT FOLDER PATH***",
-                                             help="""Please enter the full path e.g. Y:/User/troosts/chatpbl/...""")
-if st.session_state['is_EXIT_clicked']:
-    ut.exit_ui()
-if folder_path_selected != "":
-    # get folder name with docs
-    folder_name_selected = os.path.basename(folder_path_selected)
-    # available and selected documents
-    document_names = documentlist_creator(folder_path_selected)
-    document_selection = document_selector(document_names)
-    # create checkbox to indicate whether chosen documents are private or not. Default is not checked
-    # confidential = st.sidebar.checkbox(label="confidential", help="check in case of private documents")
-    confidential = False
-    # get relevant models
-    llm_provider, llm_model, embeddings_provider, embeddings_model = ut.get_relevant_models(summary=False,
-                                                                                            private=confidential)
-    # creation of Querier object, executed only once per session
-    querier = initialize_querier(my_llm_provider=llm_provider,
-                                 my_llm_model=llm_model,
-                                 my_embeddings_provider=embeddings_provider,
-                                 my_embeddings_model=embeddings_model)
 
-    # If a different folder or (set of) document(s) is chosen,
-    # clear querier history and
-    # set the go button session state 'is_go_clicked' to False
-    if ((folder_name_selected != st.session_state['folder_selected']) or
-       (document_selection != st.session_state['documents_selected'])):
-        querier.clear_history()
-        st.session_state['is_GO_clicked'] = False
-    st.session_state['folder_selected'] = folder_name_selected
-    st.session_state['documents_selected'] = document_selection
-
-    # clear querier history if a switch in confidentiality is made
-    if confidential != st.session_state['confidential']:
-        querier.clear_history()
-        st.session_state['is_GO_clicked'] = False
-    st.session_state['confidential'] = confidential
-
-    # create radio button group for summarization
-    summary_type = st.sidebar.radio(label="Start with summary?",
-                                    options=["No", "Short", "Long"],
-                                    captions=["", "Quicker and shorter", "Slower but more extensive"],
-                                    index=0)
-    # when a different summary choice is made, set the go button session state 'is_go_clicked' to False
-    if summary_type != st.session_state['is_summary_clicked']:
-        st.session_state['is_GO_clicked'] = False
-    st.session_state['is_summary_clicked'] = summary_type
-
-    # create button to confirm folder selection. This button sets session_state['is_GO_clicked'] to True when clicked
-    st.sidebar.button(label="GO", type="primary", on_click=click_go_button,
-                      help="show the prompt bar at the bottom of the screen to take questions")
-
-    # only start a conversation when a folder is selected and selection is confirmed with "GO" button
-    if st.session_state['is_GO_clicked']:
-        logger.info("GO button is clicked")
-        if len(document_selection) > 0:
-            # get relevant models
-            _, _, embeddings_provider, embeddings_model = ut.get_relevant_models(summary=False,
-                                                                                 private=confidential)
-
-            # determine name of associated vector database
-            vecdb_folder_path = ut.create_vectordb_path(content_folder_path=folder_path_selected,
-                                                        embeddings_provider=embeddings_provider,
-                                                        embeddings_model=embeddings_model)
-            # create or update vector database if necessary
-            check_vectordb(my_querier=querier,
-                           my_folder_name_selected=folder_name_selected,
-                           my_folder_path_selected=folder_path_selected,
-                           my_documents_selected=document_selection,
-                           my_vecdb_folder_path_selected=vecdb_folder_path,
-                           my_embeddings_provider=embeddings_provider,
-                           my_embeddings_model=embeddings_model)
-            # if one of the options is chosen
-            if summary_type in ["Short", "Long"]:
-                # show the summary at the top of the screen
-                create_and_show_summary(my_summary_type=summary_type,
-                                        my_folder_path_selected=folder_path_selected,
-                                        my_selected_documents=document_selection)
-            # show button "Clear Conversation"
-            clear_messages_button = st.button(label="Clear Conversation", key="clear")
-            # if button "Clear Conversation" is clicked
-            if clear_messages_button:
-                # clear all chat messages on screen and in Querier object
-                # NB: session state of "is_GO_clicked" and "folder_selected" remain unchanged
-                st.session_state['messages'] = []
-                querier.clear_history()
-                st.session_state['is_GO_clicked'] = False
-                logger.info("Clear Conversation button clicked")
-            # display chat messages from history
-            # path is needed to show source documents after the assistant's response
-            display_chat_history(folder_path_selected)
-            # react to user input if a question has been asked
-            prompt = st.chat_input("Your question")
-            if prompt:
-                handle_query(my_folder_path_selected=folder_path_selected,
-                             my_querier=querier,
-                             my_prompt=prompt,
-                             my_document_selection=document_selection,
-                             my_folder_name_selected=folder_name_selected,
-                             my_vecdb_folder_path_selected=vecdb_folder_path,
-                             question_number=len(st.session_state['messages']))
-        else:
-            st.write("Please choose one or more documents")
+# Create tabs
+tab1, tab2 = st.tabs(["Chat", "Settings"])
+with tab1:
+    try:
+        render_chat_tab()
+    except Exception as e:
+        st.error("An error occurred. Please try again.")
+        logger.error(f"Error in render_chat_tab: {str(e)}")
+with tab2:
+    try:
+        render_settings_tab()
+    except Exception as e:
+        st.error("An error occurred. Please try again.")
+        logger.error(f"Error in render_settings_tab: {str(e)}")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -635,8 +635,8 @@ def render_settings_tab():
             key='splitter'
         )
     with col2:
-        st.markdown("*Description:*")
-        st.markdown(f"<p style='font-size:10px;'>{descriptions["TEXT_SPLITTER_METHOD"]}</p>", unsafe_allow_html=True)
+        st.markdown(f"<p style='font-size:18px;'>{descriptions["TEXT_SPLITTER_METHOD"]}</p>", unsafe_allow_html=True)
+    st.divider()
 
     col1, col2 = st.columns([0.4, 0.6])
     with col1:
@@ -648,8 +648,8 @@ def render_settings_tab():
             key='chunk_size'
         )
     with col2:
-        st.markdown("*Description:*")
-        st.markdown(f"<p style='font-size:10px;'>{descriptions["CHUNK_SIZE"]}</p>", unsafe_allow_html=True)
+        st.markdown(f"<p style='font-size:18px;'>{descriptions["CHUNK_SIZE"]}</p>", unsafe_allow_html=True)
+    st.divider()
 
     col1, col2 = st.columns([0.4, 0.6])
     with col1:
@@ -661,8 +661,8 @@ def render_settings_tab():
             key='chunk_overlap'
         )
     with col2:
-        st.markdown("*Description:*")
-        st.markdown(f"<p style='font-size:10px;'>{descriptions["CHUNK_OVERLAP"]}</p>", unsafe_allow_html=True)
+        st.markdown(f"<p style='font-size:18px;'>{descriptions["CHUNK_OVERLAP"]}</p>", unsafe_allow_html=True)
+    st.divider()
 
     # Embeddings Configuration
     st.subheader("Embeddings Configuration")
@@ -677,8 +677,8 @@ def render_settings_tab():
             key='emb_provider'
         )
     with col2:
-        st.markdown("*Description:*")
-        st.markdown(f"<p style='font-size:10px;'>{descriptions["EMBEDDINGS_PROVIDER"]}</p>", unsafe_allow_html=True)
+        st.markdown(f"<p style='font-size:18px;'>{descriptions["EMBEDDINGS_PROVIDER"]}</p>", unsafe_allow_html=True)
+    st.divider()
 
     # Get available models for selected provider
     provider_models = get_provider_models()
@@ -698,8 +698,8 @@ def render_settings_tab():
             key='emb_model'
         )
     with col2:
-        st.markdown("*Description:*")
-        st.markdown(f"<p style='font-size:10px;'>{descriptions["EMBEDDINGS_MODEL"]}</p>", unsafe_allow_html=True)
+        st.markdown(f"<p style='font-size:18px;'>{descriptions["EMBEDDINGS_MODEL"]}</p>", unsafe_allow_html=True)
+    st.divider()
 
     # Retriever Configuration
     st.subheader("Retriever Configuration")
@@ -714,8 +714,8 @@ def render_settings_tab():
             key='retriever'
         )
     with col2:
-        st.markdown("*Description:*")
-        st.markdown(f"<p style='font-size:10px;'>{descriptions["RETRIEVER_TYPE"]}</p>", unsafe_allow_html=True)
+        st.markdown(f"<p style='font-size:18px;'>{descriptions["RETRIEVER_TYPE"]}</p>", unsafe_allow_html=True)
+    st.divider()
 
     if selected_retriever == "parent":
         col1, col2 = st.columns([0.4, 0.6])
@@ -728,9 +728,9 @@ def render_settings_tab():
                 key='splitter_child'
             )
         with col2:
-            st.markdown("*Description:*")
-            st.markdown(f"<p style='font-size:10px;'>{descriptions["TEXT_SPLITTER_METHOD_CHILD"]}</p>",
+            st.markdown(f"<p style='font-size:18px;'>{descriptions["TEXT_SPLITTER_METHOD_CHILD"]}</p>",
                         unsafe_allow_html=True)
+        st.divider()
 
         col1, col2 = st.columns([0.4, 0.6])
         with col1:
@@ -742,8 +742,8 @@ def render_settings_tab():
                 key='chunk_size_child'
             )
         with col2:
-            st.markdown("*Description:*")
-            st.markdown(f"<p style='font-size:10px;'>{descriptions["CHUNK_SIZE_CHILD"]}</p>", unsafe_allow_html=True)
+            st.markdown(f"<p style='font-size:18px;'>{descriptions["CHUNK_SIZE_CHILD"]}</p>", unsafe_allow_html=True)
+        st.divider()
 
         col1, col2 = st.columns([0.4, 0.6])
         with col1:
@@ -755,8 +755,9 @@ def render_settings_tab():
                 key='chunk_overlap_child'
             )
         with col2:
-            st.markdown("*Description:*")
-            st.markdown(f"<p style='font-size:10px;'>{descriptions["CHUNK_OVERLAP_CHILD"]}</p>", unsafe_allow_html=True)
+            st.markdown(f"<p style='font-size:18px;'>{descriptions["CHUNK_OVERLAP_CHILD"]}</p>", unsafe_allow_html=True)
+        st.divider()
+
     col1, col2 = st.columns([0.4, 0.6])
     with col1:
         rerank_enabled = st.checkbox(
@@ -765,8 +766,8 @@ def render_settings_tab():
             key='rerank'
         )
     with col2:
-        st.markdown("*Description:*")
-        st.markdown(f"<p style='font-size:10px;'>{descriptions["RERANK"]}</p>", unsafe_allow_html=True)
+        st.markdown(f"<p style='font-size:18px;'>{descriptions["RERANK"]}</p>", unsafe_allow_html=True)
+    st.divider()
 
     # LLM Configuration
     st.subheader("Language Model Configuration")
@@ -781,8 +782,8 @@ def render_settings_tab():
             key='llm_provider'
         )
     with col2:
-        st.markdown("*Description:*")
-        st.markdown(f"<p style='font-size:10px;'>{descriptions["LLM_PROVIDER"]}</p>", unsafe_allow_html=True)
+        st.markdown(f"<p style='font-size:18px;'>{descriptions["LLM_PROVIDER"]}</p>", unsafe_allow_html=True)
+    st.divider()
 
     # Get available models for selected provider
     available_llm_models = provider_models['llm'][selected_llm_provider]
@@ -801,8 +802,8 @@ def render_settings_tab():
             key='llm_model'
         )
     with col2:
-        st.markdown("*Description:*")
-        st.markdown(f"<p style='font-size:10px;'>{descriptions["LLM_MODEL"]}</p>", unsafe_allow_html=True)
+        st.markdown(f"<p style='font-size:18px;'>{descriptions["LLM_MODEL"]}</p>", unsafe_allow_html=True)
+    st.divider()
 
     # Save Settings Button
     if st.button("Save Settings", type="primary"):

--- a/utils.py
+++ b/utils.py
@@ -125,9 +125,6 @@ def create_vectordb_path(content_folder_path: str,
         if chunk_overlap_child is None else str(chunk_overlap_child)
     # vectordb_name is created from retriever_type, embeddings_provider, embeddings_model, and
     # parent and child text_splitter_method, chunk_size and chunk_overlap
-    # vectordb_name = retriever_type + "_" + embeddings_provider + "_" + embeddings_model + "_" + \
-    #     text_splitter_method + "_" + chunk_size + "_" + chunk_overlap + "_" + text_splitter_method_child + "_" +\
-    #     chunk_size_child + "_" + chunk_overlap_child
     vectordb_name = "_".join([retriever_type, embeddings_provider, embeddings_model, text_splitter_method, chunk_size,
                               chunk_overlap, text_splitter_method_child, chunk_size_child, chunk_overlap_child])
 

--- a/utils.py
+++ b/utils.py
@@ -100,6 +100,8 @@ def create_vectordb_path(content_folder_path: str,
         the maximum chunk size, by default None
     chunk_overlap : int, optional
         the chunk overlap, by default None
+    text_splitter_method_child : str, optional
+        name of the text splitter method used for child chunks, by default None
     chunk_size_child : int, optional
         the maximum chunk size of child chunks, by default None
     chunk_overlap_child : int, optional
@@ -121,8 +123,8 @@ def create_vectordb_path(content_folder_path: str,
     chunk_size_child = str(settings.CHUNK_SIZE_CHILD) if chunk_size_child is None else str(chunk_size_child)
     chunk_overlap_child = str(settings.CHUNK_OVERLAP_CHILD) \
         if chunk_overlap_child is None else str(chunk_overlap_child)
-    # vectordb_name is created from retriever_type, embeddings_provider, embeddings_model, text_splitter_method and
-    # parent and child chunk_size and chunk_overlap
+    # vectordb_name is created from retriever_type, embeddings_provider, embeddings_model, and
+    # parent and child text_splitter_method, chunk_size and chunk_overlap
     vectordb_name = retriever_type + "_" + embeddings_provider + "_" + embeddings_model + "_" + \
         text_splitter_method + "_" + chunk_size + "_" + chunk_overlap + "_" + text_splitter_method_child + "_" +\
         chunk_size_child + "_" + chunk_overlap_child

--- a/utils.py
+++ b/utils.py
@@ -78,6 +78,7 @@ def create_vectordb_path(content_folder_path: str,
                          text_splitter_method: str = None,
                          chunk_size: int = None,
                          chunk_overlap: int = None,
+                         text_splitter_method_child: str = None,
                          chunk_size_child: int = None,
                          chunk_overlap_child: int = None) -> str:
     """
@@ -115,14 +116,16 @@ def create_vectordb_path(content_folder_path: str,
     text_splitter_method = settings.TEXT_SPLITTER_METHOD if text_splitter_method is None else text_splitter_method
     chunk_size = str(settings.CHUNK_SIZE) if chunk_size is None else str(chunk_size)
     chunk_overlap = str(settings.CHUNK_OVERLAP) if chunk_overlap is None else str(chunk_overlap)
+    text_splitter_method_child = settings.TEXT_SPLITTER_METHOD_CHILD if text_splitter_method_child is None else \
+        text_splitter_method_child
     chunk_size_child = str(settings.CHUNK_SIZE_CHILD) if chunk_size_child is None else str(chunk_size_child)
     chunk_overlap_child = str(settings.CHUNK_OVERLAP_CHILD) \
         if chunk_overlap_child is None else str(chunk_overlap_child)
     # vectordb_name is created from retriever_type, embeddings_provider, embeddings_model, text_splitter_method and
     # parent and child chunk_size and chunk_overlap
     vectordb_name = retriever_type + "_" + embeddings_provider + "_" + embeddings_model + "_" + \
-        text_splitter_method + "_" + chunk_size + "_" + chunk_overlap + "_" + chunk_size_child + "_" + \
-        chunk_overlap_child
+        text_splitter_method + "_" + chunk_size + "_" + chunk_overlap + "_" + text_splitter_method_child + "_" +\
+        chunk_size_child + "_" + chunk_overlap_child
 
     vectordb_folder_path = os.path.join(content_folder_path, "vector_stores", vectordb_name)
 

--- a/utils.py
+++ b/utils.py
@@ -125,9 +125,11 @@ def create_vectordb_path(content_folder_path: str,
         if chunk_overlap_child is None else str(chunk_overlap_child)
     # vectordb_name is created from retriever_type, embeddings_provider, embeddings_model, and
     # parent and child text_splitter_method, chunk_size and chunk_overlap
-    vectordb_name = retriever_type + "_" + embeddings_provider + "_" + embeddings_model + "_" + \
-        text_splitter_method + "_" + chunk_size + "_" + chunk_overlap + "_" + text_splitter_method_child + "_" +\
-        chunk_size_child + "_" + chunk_overlap_child
+    # vectordb_name = retriever_type + "_" + embeddings_provider + "_" + embeddings_model + "_" + \
+    #     text_splitter_method + "_" + chunk_size + "_" + chunk_overlap + "_" + text_splitter_method_child + "_" +\
+    #     chunk_size_child + "_" + chunk_overlap_child
+    vectordb_name = "_".join([retriever_type, embeddings_provider, embeddings_model, text_splitter_method, chunk_size,
+                              chunk_overlap, text_splitter_method_child, chunk_size_child, chunk_overlap_child])
 
     vectordb_folder_path = os.path.join(content_folder_path, "vector_stores", vectordb_name)
 


### PR DESCRIPTION
It can be extended for more features but there are some redundant settings right now. 
Before querier was not keeping track of chat_history (with every question chat history was removed). I thought this wasn't intended feature. 
When any settings changed chat history will be retained unless it is indicated otherwise. 
Since there is a change to tab style of streamlit, old behavior of UI is gone. To fix that partially CSS in initialize page is accommodating new style for chat-input class to keep it in fixed position similar to old one. But I couldn't handle the smooth scrolling of chat page at the bottom. 
Lastly, at the change of text splitter, embeddings, retriever and rerank, we can trigger new ingest and create new vector stores for improvement