### PR TITLE
chroma telemetry disabled

### DIFF
--- a/ingest/ingester.py
+++ b/ingest/ingester.py
@@ -264,10 +264,7 @@ class Ingester:
             to_add = list(relevant_files_in_folder_selected)
 
         # If there are any files to be ingested into the vector store
-        if ut.check_size(to_add, self.content_folder) > settings.MAX_INGESTION_SIZE:
-            logger.error(f"Size of the files to be ingested exceeds the limit of {settings.MAX_INGESTION_SIZE} MB")
-            return f"Size of the files to be ingested exceeds the limit of {settings.MAX_INGESTION_SIZE} MB"
-        elif len(to_add) > 0:
+        if len(to_add) > 0:
             logger.info(f"Files are added, so vector store for {self.content_folder} needs to be updated")
             # create FileParser object
             file_parser = FileParser()

--- a/ingest/ingester.py
+++ b/ingest/ingester.py
@@ -264,7 +264,10 @@ class Ingester:
             to_add = list(relevant_files_in_folder_selected)
 
         # If there are any files to be ingested into the vector store
-        if len(to_add) > 0:
+        if ut.check_size(to_add, self.content_folder) > settings.MAX_INGESTION_SIZE:
+            logger.error(f"Size of the files to be ingested exceeds the limit of {settings.MAX_INGESTION_SIZE} MB")
+            return f"Size of the files to be ingested exceeds the limit of {settings.MAX_INGESTION_SIZE} MB"
+        elif len(to_add) > 0:
             logger.info(f"Files are added, so vector store for {self.content_folder} needs to be updated")
             # create FileParser object
             file_parser = FileParser()

--- a/ingest/vectorstore_creator.py
+++ b/ingest/vectorstore_creator.py
@@ -2,6 +2,7 @@
 VectorStore class to be used in other modules
 """
 # imports
+from chromadb.config import Settings
 from langchain_chroma import Chroma
 
 
@@ -30,11 +31,16 @@ class VectorStoreCreator():
         # if content_folder contains whitespaces, replace them with underscores
         content_folder = content_folder.replace(" ", "_")
 
+        client_settings = Settings(
+            anonymized_telemetry=False
+        )
+
         vectorstore = Chroma(
             collection_name=content_folder,
             embedding_function=embeddings,
             persist_directory=vecdb_folder,
-            collection_metadata={"hnsw:space": "cosine"}
-            )
+            collection_metadata={"hnsw:space": "cosine"},
+            client_settings=client_settings
+        )
 
         return vectorstore

--- a/settings_template.py
+++ b/settings_template.py
@@ -201,3 +201,6 @@ CHAIN_TYPE = "stuff"
 # value must be one of "openai_rag", "openai_rag_concise", "openai_rag_language", "yesno"
 # see file prompt_templates.py for explanation
 RETRIEVER_PROMPT_TEMPLATE = "openai_rag"
+
+# MAX_INGESTION_SIZE represents the maximum size of the folder in MB
+MAX_INGESTION_SIZE = 20

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -221,6 +221,9 @@ def check_vectordb(my_querier: Querier,
                             chunk_size_child=my_chunk_size_child,
                             chunk_overlap_child=my_chunk_overlap_child)
         ingester.ingest()
+        error_text = ingester.ingest()
+        if error_text:
+            st.error(error_text)
 
     # create a new chain based on the new source folder
     my_querier.make_chain(my_folder_name_selected, my_vecdb_folder_path_selected)
@@ -991,6 +994,7 @@ def render_chat_tab(developer_mode):
         if ((folder_name_selected != st.session_state['folder_selected']) or
            (document_selection != st.session_state['documents_selected'])):
             querier.clear_history()
+            st.session_state['messages'] = []
             st.session_state['chat_history'] = []
             st.session_state['is_GO_clicked'] = False
         st.session_state['folder_selected'] = folder_name_selected
@@ -999,6 +1003,7 @@ def render_chat_tab(developer_mode):
         # clear querier history if a switch in confidentiality is made
         if confidential != st.session_state['confidential']:
             querier.clear_history()
+            st.session_state['messages'] = []
             st.session_state['chat_history'] = []
             st.session_state['is_GO_clicked'] = False
         st.session_state['confidential'] = confidential

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -220,10 +220,10 @@ def check_vectordb(my_querier: Querier,
                             text_splitter_method_child=my_text_splitter_method_child,
                             chunk_size_child=my_chunk_size_child,
                             chunk_overlap_child=my_chunk_overlap_child)
-        ingester.ingest()
-        error_text = ingester.ingest()
-        if error_text:
-            st.error(error_text)
+        if ut.check_size(my_folder_path_selected, my_documents_selected) <= settings_template.MAX_INGESTION_SIZE:
+            ingester.ingest()
+        else:
+            st.error(f"Size of the files to be ingested exceeds the limit of {settings_template.MAX_INGESTION_SIZE} MB")
 
     # create a new chain based on the new source folder
     my_querier.make_chain(my_folder_name_selected, my_vecdb_folder_path_selected)

--- a/utils.py
+++ b/utils.py
@@ -408,3 +408,23 @@ def answer_idontknow(language: str) -> str:
         result = "I don't know because there is no relevant context containing the answer"
 
     return result
+
+
+def check_size(list_of_files, content_folder):
+    """
+    Checks the size of the list of files and returns the size of files in memory
+    Parameters
+    ----------
+    list_of_files : List[str]
+        list of files
+    content_folder : str
+    Returns
+    -------
+    float
+        size of files in MB
+    """
+    size = 0
+    for file in list_of_files:
+        size += os.path.getsize(os.path.join(content_folder, file))
+    size = size / 1024 / 1024  # convert to MB
+    return size

--- a/utils.py
+++ b/utils.py
@@ -428,4 +428,4 @@ def check_size(content_folder, document_selection):
     for file in list_of_files:
         size += os.path.getsize(os.path.join(content_folder, file))
     size = size / 1024 / 1024  # convert to MB
-    return 5
+    return size

--- a/utils.py
+++ b/utils.py
@@ -410,7 +410,7 @@ def answer_idontknow(language: str) -> str:
     return result
 
 
-def check_size(list_of_files, content_folder):
+def check_size(content_folder, document_selection):
     """
     Checks the size of the list of files and returns the size of files in memory
     Parameters
@@ -423,8 +423,9 @@ def check_size(list_of_files, content_folder):
     float
         size of files in MB
     """
+    list_of_files = get_relevant_files_in_folder(content_folder, document_selection)
     size = 0
     for file in list_of_files:
         size += os.path.getsize(os.path.join(content_folder, file))
     size = size / 1024 / 1024  # convert to MB
-    return size
+    return 5


### PR DESCRIPTION
Chroma collects anonymized telemetry data and uses posthog for this, see also https://docs.trychroma.com/docs/overview/telemetry

This can slow down the application and can even prevent the application from working properly, as noted by Steven Veenma:

"Tijdje geleden dat we contact hadden. Wij hebben de afgelopen tijd een AVD en webapp frontend architectuur ingericht en ik ben nu bezig om daarop RAG te testen. Ik heb daarom ook Docchat weer opgepakt. Ik zag dat je nog hebt doorontwikkeld. Inmiddels heb ik Azure OpenAI aan de praat. Ik heb inmiddels een vector-store van onze data gemaakt. Maar ik loop bij gebruik van de query.py tegen een issue aan. Ik krijg binnen de AVD (die zeer secure is ingericht) de volgende melding: Question: INFO:backoff:Backing off send_request(...) for 0.1s (requests.exceptions.SSLError: HTTPSConnectionPool(host='us.i.posthog.com', port=443): Max retries exceeded with url: /batch/ (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1006)'))))
 
Ik heb hier samen met onze solution architect naar gekeken. Posthog wijst op een library die in de requirements en settings wordt genoemd en die iets doet met registratie van gebruik. Ik heb hem er maar eens afgegooid om te zien wat er gebeurd en dan krijg ik de volgende melding:  "C:\Users\veenmas\docchat\Lib\site-packages\chromadb\telemetry\product\posthog.py", line 1, in <module>    import posthog
 
Ben jij je bewust van Posthog, eventuele veiligheidsrisico’s en kunnen we er zonder?
"