### PR TITLE
in-memory processing

### DIFF
--- a/ingest/ingester.py
+++ b/ingest/ingester.py
@@ -31,7 +31,8 @@ class Ingester:
                  document_selection: List[str] = None, embeddings_provider: str = None, embeddings_model: str = None,
                  retriever_type: str = None, text_splitter_method: str = None,
                  text_splitter_method_child: str = None, chunk_size: int = None, chunk_size_child: int = None,
-                 chunk_overlap: int = None, chunk_overlap_child: int = None) -> None:
+                 chunk_overlap: int = None, chunk_overlap_child: int = None, vector_store=None,
+                 in_memory=False) -> None:
         load_dotenv(dotenv_path=os.path.join(settings.ENVLOC, ".env"))
         self.collection_name = collection_name
         self.content_folder = content_folder
@@ -48,6 +49,8 @@ class Ingester:
             if text_splitter_method_child is None else text_splitter_method_child
         self.chunk_size_child = settings.CHUNK_SIZE_CHILD if chunk_size_child is None else chunk_size_child
         self.chunk_overlap_child = settings.CHUNK_OVERLAP_CHILD if chunk_overlap_child is None else chunk_overlap_child
+        self.vector_store = vector_store
+        self.in_memory = in_memory
 
     def merge_hyphenated_words(self, text: str) -> str:
         """
@@ -209,14 +212,15 @@ class Ingester:
                                                                             self.document_selection)
         relevant_files_in_folder_all = ut.get_relevant_files_in_folder(self.content_folder)
         # if the vector store already exists, get the set of ingested files from the vector store
-        if os.path.exists(self.vecdb_folder):
+        if ((self.vecdb_folder is not None) and os.path.exists(self.vecdb_folder)) or (self.vector_store is not None):
             # get vector store
-            vector_store = VectorStoreCreator().get_vectorstore(embeddings,
-                                                                self.collection_name,
-                                                                self.vecdb_folder)
+            if self.vector_store is None:
+                self.vector_store = VectorStoreCreator().get_vectorstore(embeddings,
+                                                                         self.collection_name,
+                                                                         self.vecdb_folder)
             logger.info(f"Vector store already exists for specified settings and folder {self.content_folder}")
             # determine the files that are added or deleted
-            collection = vector_store.get()  # dict_keys(['ids', 'embeddings', 'documents', 'metadatas'])
+            collection = self.vector_store.get()  # dict_keys(['ids', 'embeddings', 'documents', 'metadatas'])
             files_in_store = [metadata['filename'] for metadata in collection['metadatas']]
             files_in_store = list(set(files_in_store))
 
@@ -244,11 +248,11 @@ class Ingester:
                     idx_metadata = collection['metadatas'][idx]
                     if idx_metadata['filename'] in to_delete:
                         idx_id_to_delete.append(idx_id)
-                        if idx_metadata['filename'].endswith(".docx"):
+                        if idx_metadata['filename'].endswith(".docx") and not self.in_memory:
                             os.remove(os.path.join(self.content_folder,
                                                    "conversions",
                                                    idx_metadata['filename'] + ".pdf"))
-                vector_store.delete(idx_id_to_delete)
+                self.vector_store.delete(idx_id_to_delete)
                 logger.info("Deleted files from vectorstore")
 
             # add to vector store all chunks associated with added or updated files
@@ -257,9 +261,10 @@ class Ingester:
         else:
             logger.info(f"Vector store to be created for folder {self.content_folder}")
             # get chroma vector store
-            vector_store = VectorStoreCreator().get_vectorstore(embeddings,
-                                                                self.collection_name,
-                                                                self.vecdb_folder)
+            # This should also create in-memory vector store in case vecbd_folder is None
+            self.vector_store = VectorStoreCreator().get_vectorstore(embeddings,
+                                                                     self.collection_name,
+                                                                     self.vecdb_folder)
             # all relevant files in the folder are to be ingested into the vector store
             to_add = list(relevant_files_in_folder_selected)
 
@@ -273,7 +278,7 @@ class Ingester:
                 file_path = os.path.join(self.content_folder, file)
                 # extract raw text pages and metadata according to file type
                 logger.info(f"Parsing file {file}")
-                raw_texts, metadata = file_parser.parse_file(file_path)
+                raw_texts, metadata = file_parser.parse_file(file_path, self.in_memory)
                 documents = self.clean_texts_to_docs(raw_texts=raw_texts,
                                                      metadata=metadata)
                 # count tokens
@@ -282,7 +287,7 @@ class Ingester:
                 if tokens_document > 40_000:
                     logger.info("Pause for 10 seconds to avoid hitting rate limit")
                     time.sleep(10)
-                vector_store.add_documents(
+                self.vector_store.add_documents(
                     documents=documents,
                     embedding=embeddings,
                     collection_name=self.collection_name,

--- a/query/querier.py
+++ b/query/querier.py
@@ -92,9 +92,10 @@ class Querier:
             _description_, by default None
         """
         # get vector store
-        self.vector_store = VectorStoreCreator().get_vectorstore(embeddings=self.embeddings,
-                                                                 content_folder=content_folder,
-                                                                 vecdb_folder=vecdb_folder)
+        if self.vector_store is None:
+            self.vector_store = VectorStoreCreator().get_vectorstore(embeddings=self.embeddings,
+                                                                     content_folder=content_folder,
+                                                                     vecdb_folder=vecdb_folder)
         logger.info(f"Loaded vector store from folder {vecdb_folder}")
 
         # get retriever with search_filter

--- a/summarize.py
+++ b/summarize.py
@@ -39,7 +39,9 @@ def main():
         elif summarization_method == "m":
             summarization_method = "map_reduce"
         # create subfolder for storage of summaries if not existing
-        ut.create_summaries_folder(content_folder_path)
+        is_in_memory = ut.is_in_memory(content_folder_path)
+        if not is_in_memory:
+            ut.create_summaries_folder(content_folder_path)
         # content_folder_path, _ = ut.create_vectordb_path(content_folder_name)
         summarizer = Summarizer(content_folder_path=content_folder_path,
                                 summarization_method=summarization_method,
@@ -47,10 +49,15 @@ def main():
                                 chunk_size=settings.SUMMARY_CHUNK_SIZE,
                                 chunk_overlap=settings.SUMMARY_CHUNK_OVERLAP,
                                 llm_provider=llm_provider,
-                                llm_model=llm_model)
+                                llm_model=llm_model,
+                                in_memory=is_in_memory)
         logger.info(f"Starting summarizer with method {summarization_method}")
-        summarizer.summarize_folder()
-        logger.info(f"{content_folder_name} successfully summarized.")
+        if is_in_memory:
+            logger.info(f"Summarizing in memory for {content_folder_name}")
+            logger.info(f"SUMMARIES \n\n {summarizer.summarize_folder()}")
+        else:
+            summarizer.summarize_folder()
+            logger.info(f"{content_folder_name} successfully summarized.")
 
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -429,3 +429,24 @@ def check_size(content_folder, document_selection):
         size += os.path.getsize(os.path.join(content_folder, file))
     size = size / 1024 / 1024  # convert to MB
     return size
+
+
+def check_in_memory_storage(folder_path) -> bool:
+    """
+    Checks whether to store variables in memory or not by trying to create a test folder
+    Parameters
+    ----------
+    folder_path : str
+        path of the folder
+    Returns
+    -------
+    bool
+        True if in memory, False otherwise
+    """
+    try:
+        os.mkdir(os.path.join(folder_path, "test"))
+        os.rmdir(os.path.join(folder_path, "test"))
+        return False
+    except Exception:
+        logger.info("We are in memory")
+        return True


### PR DESCRIPTION
file_parser: in case of in-memory, docx file not converted to pdf
ingester: vector_store can be passed as an argument and do not allow in-memory mode to write on conversion folder
querier: do not allow make_chain to get_vectorstore again in case vector_store is present
utils: checks whether a folder is writable for current user and decides for in_memory mode
summarizer: in_memory can be passed as an argument. Instead of writing on disk stores in memory.
summarize: some changes according to above changes
streamlit_app: New session states added. When in-memory is True, summaries and vector_store will be stored in memory,

Note: vector_store is instantiated with "my_vecdb_folder_path_selected = None" in streamlit_app.check_vectordb , in order to reject persist directory.